### PR TITLE
Change JAVA_HOME value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ RUN buildDeps='software-properties-common'; \
   apt-get purge -y --auto-remove $buildDeps && \
   apt-get autoremove -y && apt-get clean
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64


### PR DESCRIPTION
Since the change of JDK from Oracle to OpenJDK the variable JAVA_HOME was not updated to point to the correct location.